### PR TITLE
docs: load the @mantine/dates stylesheet the credit-card demo needs

### DIFF
--- a/docs/demos/Flip.demo.credit-card.tsx
+++ b/docs/demos/Flip.demo.credit-card.tsx
@@ -17,6 +17,10 @@ import { MantineDemo } from '@mantinex/demo';
 import { useEffect, useState } from 'react';
 
 const code = `
+// MonthPickerInput lives in @mantine/dates, which ships its own stylesheet:
+// without this import the picker renders unstyled.
+import '@mantine/dates/styles.css';
+
 import { useEffect, useState } from 'react';
 import { Flip } from '@gfazioli/mantine-flip';
 import {

--- a/docs/pages/_app.tsx
+++ b/docs/pages/_app.tsx
@@ -1,6 +1,7 @@
 import '@mantine/core/styles.css';
 // Core
 import '@mantine/code-highlight/styles.css';
+import '@mantine/dates/styles.css';
 import '@mantinex/demo/styles.css';
 import '@mantinex/mantine-header/styles.css';
 import '@mantinex/mantine-logo/styles.css';


### PR DESCRIPTION
The Expire field in **Example: Credit card** is a `MonthPickerInput` from `@mantine/dates`, and `docs/pages/_app.tsx` imported `@mantine/core/styles.css` and `@mantine/code-highlight/styles.css` but never `@mantine/dates/styles.css`. The package was a declared dependency and the component rendered fine, so nothing failed — the dropdown just came up unstyled.

**Measured, not eyeballed.** `.m_14c23465` is a hashed selector present in `@mantine/dates/styles.css` and in no other Mantine stylesheet, which makes it a clean probe:

| | loaded rules containing the probe | `MonthPickerInput` elements in the DOM |
|---|---|---|
| published docs (pre-fix) | **0** | 6 |
| local (post-fix) | **10** | 6 |

The component was always there; its stylesheet wasn't.

**Two faces, one cause.** The demo's *displayed* code had the same hole one level out: it imports `MonthPickerInput` and never mentioned the stylesheet, so a reader copy-pasting the snippet into an app that imports only the core styles would reproduce exactly the broken picker. That import is now in the snippet, with a comment saying what happens without it.

**Blast radius, checked.** Swept the other 29 docs sites for the same shape — a Mantine package used in docs whose stylesheet is never imported — and this is the only one; every other site uses only `core` + `code-highlight` and imports both. No published package imports a Mantine package that ships CSS, so **no consumer of the libraries is affected**. Docs-only, no release needed.